### PR TITLE
Handling pages with no jquery, removing highlights, waiting for page load

### DIFF
--- a/website_diff/crawler.py
+++ b/website_diff/crawler.py
@@ -42,6 +42,9 @@ def crawl(filepath, gathered, content_selector = 'html', crawled = None):
     	for link in elem.find_all('a'):
             # extract the url
             ref = link.get('href')
+            # skip <a> tags without href properties
+            if ref is None:
+                continue
             # remove anchors
             ref = ref.split('#')[0]
             # parse the url

--- a/website_diff/page.py
+++ b/website_diff/page.py
@@ -104,6 +104,9 @@ def highlight_links(file, root, add_pages, del_pages, diff_pages):
     for link in soup.select('a'):
         # extract the url
         ref = link.get('href')
+        # skip <a> tags without href properties
+        if ref is None:
+            continue
         # remove anchors
         ref = ref.split('#')[0]
         # parse the url

--- a/website_diff/page.py
+++ b/website_diff/page.py
@@ -20,7 +20,7 @@ def _merge_diffs(elem, soup):
 
     if elem.contents:
         next_child = elem.contents[0]
-    else: 
+    else:
         return
 
     while next_child is not None:
@@ -43,7 +43,7 @@ def _merge_diffs(elem, soup):
     if len(elem.contents) == 1 and elem.name in ['ins', 'del'] and child == '\n':
         elem.decompose()
     else:
-        _merge_previous(elem)  
+        _merge_previous(elem)
 
 def diff(filepath_old, filepath_new, diff_images, root_element, out_root, filepath_out):
     # load the html files
@@ -77,7 +77,9 @@ def diff(filepath_old, filepath_new, diff_images, root_element, out_root, filepa
 
     # append the js/css files
     js_soup = BeautifulSoup('<script src="website_diff.js"></script>', 'html.parser')
+    jq_soup = BeautifulSoup('<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>', 'html.parser')
     css_soup = BeautifulSoup('<link rel="stylesheet" href="website_diff.css" type="text/css"/>', 'html.parser')
+    soup.select_one("head").append(jq_soup)
     soup.select_one("head").append(js_soup)
     soup.select_one("head").append(css_soup)
 

--- a/website_diff/page.py
+++ b/website_diff/page.py
@@ -20,7 +20,7 @@ def _merge_diffs(elem, soup):
 
     if elem.contents:
         next_child = elem.contents[0]
-    else:
+    else: 
         return
 
     while next_child is not None:
@@ -43,7 +43,7 @@ def _merge_diffs(elem, soup):
     if len(elem.contents) == 1 and elem.name in ['ins', 'del'] and child == '\n':
         elem.decompose()
     else:
-        _merge_previous(elem)
+        _merge_previous(elem)  
 
 def diff(filepath_old, filepath_new, diff_images, root_element, out_root, filepath_out):
     # load the html files
@@ -77,9 +77,7 @@ def diff(filepath_old, filepath_new, diff_images, root_element, out_root, filepa
 
     # append the js/css files
     js_soup = BeautifulSoup('<script src="website_diff.js"></script>', 'html.parser')
-    jq_soup = BeautifulSoup('<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>', 'html.parser')
     css_soup = BeautifulSoup('<link rel="stylesheet" href="website_diff.css" type="text/css"/>', 'html.parser')
-    soup.select_one("head").append(jq_soup)
     soup.select_one("head").append(js_soup)
     soup.select_one("head").append(css_soup)
 

--- a/website_diff/static/website_diff.css
+++ b/website_diff/static/website_diff.css
@@ -4,12 +4,12 @@ del.diff, del.diff * {
 ins.diff, ins.diff * {
 	background-color: lightgreen;
 }
-del.diff-selected, del.diff-selected * {
+/*del.diff-selected, del.diff-selected * {
 	background-color: firebrick;
 }
 ins.diff-selected, ins.diff-selected * {
 	background-color: limegreen;
-}
+}*/
 
 del.diff:has(img) {
 	background-color: transparent;
@@ -27,13 +27,14 @@ ins.diff > img {
 	border: 0.7rem solid lightgreen !important;
 }
 
+/*
 del.diff-selected > img {
 	border: 0.7rem solid firebrick !important;
 }
 
 ins.diff-selected > img {
 	border: 0.7rem solid limegreen !important;
-}
+}*/
 
 .link-to-diff {
 	color: darkgoldenrod !important;

--- a/website_diff/static/website_diff.js
+++ b/website_diff/static/website_diff.js
@@ -1,6 +1,6 @@
 var diffidx = 0;
 
-$(document).ready(function() {
+$(window).on("load", function() {
    // highlight and scroll to the first diff element
    var cur;
    cur = $(".diff:visible").eq(diffidx)

--- a/website_diff/static/website_diff.js
+++ b/website_diff/static/website_diff.js
@@ -35,8 +35,10 @@ function isElementVisible(el) {
 function scrollToFirstDiff(diffidx) {
   var cur;
   cur = $(".diff:visible").eq(diffidx)
-  cur.addClass("diff-selected");
-  $(cur)[0].scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest"});
+  if (typeof cur[0] != "undefined") {
+    cur.addClass("diff-selected");
+    $(cur)[0].scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest"});
+  }
 }
 
 // Scroll to the next diff element on pressing n, previous on pressing Shift + n
@@ -45,6 +47,9 @@ function scrollToNextDiff(diffidx) {
     var cur;	
     var next;
     cur = $(".diff:visible").eq(diffidx)
+    if (typeof cur[0] == "undefined") {
+      return;
+    }
     cur.removeClass("diff-selected");
     if (e.which == 110){
      

--- a/website_diff/static/website_diff.js
+++ b/website_diff/static/website_diff.js
@@ -5,12 +5,9 @@ if (typeof jQuery == 'undefined') {
 
 var diffidx = 0;
 
-$(window).on("load", function() {
-   // highlight and scroll to the first diff element
-   var cur;
-   cur = $(".diff:visible").eq(diffidx)
-   cur.addClass("diff-selected");
-   $(cur)[0].scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest"});
+window.addEventListener('load', () => {
+  scrollToFirstDiff(diffidx);
+  scrollToNextDiff(diffidx);
 });
 
 // Borrowed from https://stackoverflow.com/a/15203639
@@ -34,51 +31,61 @@ function isElementVisible(el) {
   );
 }
 
-$(document).on("keypress", function(e) {
-   var cur;	
-   var next;
-   cur = $(".diff:visible").eq(diffidx)
-   cur.removeClass("diff-selected");
-   if (e.which == 110){
-    
-    var diffidx_tmp = diffidx + 1;
-    if (diffidx_tmp > $(".diff:visible").length-1){
-      diffidx_tmp = $(".diff:visible").length-1;
-    }
-    var cur_tmp = $(".diff:visible").eq(diffidx_tmp);
+// Scroll to the center of first diff element on page
+function scrollToFirstDiff(diffidx) {
+  var cur;
+  cur = $(".diff:visible").eq(diffidx)
+  cur.addClass("diff-selected");
+  $(cur)[0].scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest"});
+}
 
-    while (isElementVisible(cur_tmp[0])) {
-      diffidx_tmp += 1;
-      if (diffidx_tmp > $(".diff:visible").length-1){
-          diffidx_tmp = $(".diff:visible").length-1;
-          break
-      }
-      cur_tmp = $(".diff:visible").eq(diffidx_tmp)
-    }
-    cur = cur_tmp
-    diffidx = diffidx_tmp
-   } 
-   if (e.which == 78) {
+// Scroll to the next diff element on pressing n, previous on pressing Shift + n
+function scrollToNextDiff(diffidx) {
+  $(document).on("keypress", function(e) {
+    var cur;	
+    var next;
+    cur = $(".diff:visible").eq(diffidx)
+    cur.removeClass("diff-selected");
+    if (e.which == 110){
      
-     var diffidx_tmp = diffidx - 1;
-     if (diffidx_tmp < 0){
-      diffidx_tmp = 0;
+     var diffidx_tmp = diffidx + 1;
+     if (diffidx_tmp > $(".diff:visible").length-1){
+       diffidx_tmp = $(".diff:visible").length-1;
      }
      var cur_tmp = $(".diff:visible").eq(diffidx_tmp);
-
+ 
      while (isElementVisible(cur_tmp[0])) {
-      diffidx_tmp -= 1;
-      if (diffidx_tmp < 0){
-        diffidx_tmp = 0;
-        break
-      }
-      cur_tmp = $(".diff:visible").eq(diffidx_tmp)
+       diffidx_tmp += 1;
+       if (diffidx_tmp > $(".diff:visible").length-1){
+           diffidx_tmp = $(".diff:visible").length-1;
+           break
+       }
+       cur_tmp = $(".diff:visible").eq(diffidx_tmp)
      }
      cur = cur_tmp
      diffidx = diffidx_tmp
-   }
-   next = $(".diff:visible").eq(diffidx)
-   next.addClass("diff-selected")
-   $(next)[0].scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest"});
-});
-
+    } 
+    if (e.which == 78) {
+      
+      var diffidx_tmp = diffidx - 1;
+      if (diffidx_tmp < 0){
+       diffidx_tmp = 0;
+      }
+      var cur_tmp = $(".diff:visible").eq(diffidx_tmp);
+ 
+      while (isElementVisible(cur_tmp[0])) {
+       diffidx_tmp -= 1;
+       if (diffidx_tmp < 0){
+         diffidx_tmp = 0;
+         break
+       }
+       cur_tmp = $(".diff:visible").eq(diffidx_tmp)
+      }
+      cur = cur_tmp
+      diffidx = diffidx_tmp
+    }
+    next = $(".diff:visible").eq(diffidx)
+    next.addClass("diff-selected")
+    $(next)[0].scrollIntoView({ behavior: "smooth", block: "center", inline: "nearest"});
+ });
+}

--- a/website_diff/static/website_diff.js
+++ b/website_diff/static/website_diff.js
@@ -1,3 +1,8 @@
+// dynamically load jQuery if not already present on the website
+if (typeof jQuery == 'undefined') {
+  document.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>');
+}
+
 var diffidx = 0;
 
 $(window).on("load", function() {

--- a/website_diff/static/website_diff.js
+++ b/website_diff/static/website_diff.js
@@ -1,8 +1,3 @@
-// dynamically load jQuery if not already present on the website
-if (typeof jQuery == 'undefined') {
-  document.write('<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>');
-}
-
 var diffidx = 0;
 
 $(window).on("load", function() {


### PR DESCRIPTION
- Closes #14 
- Closes #15   --- but I'm not totally happy with this solution (it might end up conflicting with an existing version of jquery...)
- Closes #17 
- Closes #20 

Re #15 : @briank-git do you think we can reimplement `website_diff.js` without using jQuery? Just with base javascript, to avoid having to deal with dependencies? Or maybe you have a better idea how to handle dependencies

It would also be good if we solved #21 here

I think my solution for #14 , #17 , and #20 should be fine already