### PR TITLE
Error if diff folder exists, normalize ref path

### DIFF
--- a/website_diff/cli.py
+++ b/website_diff/cli.py
@@ -22,6 +22,10 @@ def main(old, new, diff, selector, index):
     logger.remove()
     logger.add(sys.stderr, level="INFO")
 
+    # Throw error if diff folder already exists
+    if os.path.exists(diff):
+        sys.exit(f"ERROR: Diff folder {diff} already exists.")
+
     # copy over the new directory to the diff directory
     # also ensure directory doesn't exist before this code runs
     # copy the js/css to all subdirs (just brute forcing this for now...)

--- a/website_diff/page.py
+++ b/website_diff/page.py
@@ -112,15 +112,14 @@ def highlight_links(file, root, add_pages, del_pages, diff_pages):
         logger.debug(f"Found link in {file}: {ref}")
         logger.debug(f"Parsed link: {url}")
         if not bool(url.netloc) and ref[-5:] == '.html':
-            # this is a relative path to an html file. Find path relative to root
-            #relative_link_path = os.path.relpath(os.path.normpath(os.path.join(curdir, ref)), diff)
-            if url.path in diff_pages:
+            path = os.path.normpath(url.path)
+            if path in diff_pages:
                 logger.debug(f"This is a relative path to a diff'd page. Highlighting")
                 link['class'] = link.get('class', []) + ["link-to-diff"]
-            elif url.path in add_pages:
+            elif path in add_pages:
                 logger.debug(f"This is a relative path to an added page. Highlighting")
                 link['class'] = link.get('class', []) + ["link-to-add"]
-            elif url.path in del_pages:
+            elif path in del_pages:
                 logger.debug(f"This is a relative path to a deleted page. Highlighting")
                 link['class'] = link.get('class', []) + ["link-to-del"]
             else:


### PR DESCRIPTION
Closes #19.
- Simple error is now thrown if diff folder exists, no more complicated stack trace.

Closes #21.
- Normalize the ref path before the comparisons so links are properly highlighted. On certain websites the path contained './' in front of the path meaning the following list comparisons would fail as those paths do not have that prepended.