### PR TITLE
Use v4 of gh-pages actions for node compatibility

### DIFF
--- a/.github/workflow-templates/example_workflow.yml
+++ b/.github/workflow-templates/example_workflow.yml
@@ -63,7 +63,7 @@ jobs:
       # Push the diff version of the website to the gh-pages branch
       # the diff version will be stored in a folder named diff### (where ### is the PR number)
       - name: Push the diff version of the website to the gh-pages branch
-        uses: peaceiris/actions-gh-pages@v3.8.0
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: diff${{ github.event.number }}


### PR DESCRIPTION
I see warnings with 3.8, it uses node 12 but github actions require node 20. See e.g. https://github.com/joelostblom/viz-oer/actions/runs/10911253357. 4 is the latest version here https://github.com/peaceiris/actions-gh-pages