### PR TITLE
Render plotly and misc bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ files remain constant.
 ## Installation
 Ensure Rust and Cargo are installed. Instructions can be found [here](https://www.rust-lang.org/tools/install).
 
+You may also need to [install the cairo library](https://www.cairographics.org/download/) if your distribution does not include it.
+
 ```
 pip install --upgrade pip
 pip install website_diff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "website_diff"
-version = "0.0.1"
+version = "0.1.0"
 description = "A simple tool for producing navigable, highlighted diffs of rendered HTML websites"
 requires-python = ">=3.9"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "numpy",
     "vl-convert-python",
     "selenium",
+    "cairosvg",
     "maturin"
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "Pillow",
     "numpy",
     "vl-convert-python",
+    "selenium",
     "maturin"
 ]
 classifiers = [

--- a/website_diff/cli.py
+++ b/website_diff/cli.py
@@ -118,6 +118,9 @@ def main(old, new, diff, selector, index):
             if is_diff:
                 diff_pages.add(page)
 
+        # Add banners to new and deleted pages
+        wd.page.put_banner(diff, add_pages, del_pages)
+            
         ## loop over all pages, modifying <a> tags that point to pages with diffs with highlights
         logger.info(f"Highlighting links to diff'd pages")
         for page in com_pages:

--- a/website_diff/crawler.py
+++ b/website_diff/crawler.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import website_diff as wd
 from urllib.parse import urlparse
 from bs4 import BeautifulSoup
 from loguru import logger
@@ -77,6 +78,22 @@ def gather_local_images(filepath, soup, root_element, gathered):
         if not bool(url.netloc):
             # this is a relative image.
             imgpath = os.path.normpath(os.path.join(curdir, src))
+            # Convert any svg files to png
+            if src.split('.')[-1] == 'svg':
+                logger.info(f"SVG {imgpath} found, converting to PNG.") 
+
+                src_png = os.path.splitext(src)[0] + ".png"
+                imgpath_png = os.path.splitext(imgpath)[0] + ".png"
+
+                wd.target.image.convert_svg_to_png(imgpath, imgpath_png)
+
+                img['src'] = src_png
+
+                # Write change to img src attribute
+                with open(filepath, 'w') as f:
+                    f.write(str(soup))
+
+                imgpath = imgpath_png
             logger.debug(f"This is a relative image path. Adding {imgpath} to images")
             gathered.add(imgpath)
         else:

--- a/website_diff/page.py
+++ b/website_diff/page.py
@@ -130,5 +130,28 @@ def highlight_links(file, root, add_pages, del_pages, diff_pages):
     with open(os.path.join(root, file), 'w') as f:
         f.write(str(soup))
 
-
+# Add banner to pages that were added or deleted
+# TAKES: 
+# diff_path - Path to diff folder
+# add_pages - Set of added pages
+# del_pages - Set of deleted pages
+# RETURNS: nothing
+def put_banner(diff_path, add_pages, del_pages):
+    for page in add_pages.union(del_pages):
+        with open(os.path.join(diff_path, page), 'r') as f:
+            html_add = f.read()
+        soup = BeautifulSoup(html_add, "html.parser")
+        if page in add_pages:
+            markup = """<div class='alert add-banner'><span class='closebtn' onclick="this.parentElement.style.display='none';">&times;</span>This is an added page.</div>"""
+        else:
+            markup = """<div class='alert del-banner'><span class='closebtn' onclick="this.parentElement.style.display='none';">&times;</span>This is a deleted page.</div>"""
+        markup_soup = BeautifulSoup(markup, 'html.parser')
+        soup.body.insert(1, markup_soup.div)
+        # add css
+        css_soup = BeautifulSoup('<link rel="stylesheet" href="website_diff.css" type="text/css"/>', 'html.parser')
+        soup.select_one("head").append(css_soup)
+        # write the page w/ banner
+        with open(os.path.join(diff_path, page), 'w') as f:
+            f.write(str(soup))
+        
 

--- a/website_diff/page.py
+++ b/website_diff/page.py
@@ -42,7 +42,7 @@ def _merge_diffs(elem, soup):
     # Delete element if all it contains is a newline character
     if len(elem.contents) == 1 and elem.name in ['ins', 'del'] and child == '\n':
         elem.decompose()
-    else:
+    elif elem.name in ['ins', 'del']:
         _merge_previous(elem)  
 
 def diff(filepath_old, filepath_new, diff_images, root_element, out_root, filepath_out):

--- a/website_diff/page.py
+++ b/website_diff/page.py
@@ -112,7 +112,7 @@ def highlight_links(file, root, add_pages, del_pages, diff_pages):
         logger.debug(f"Found link in {file}: {ref}")
         logger.debug(f"Parsed link: {url}")
         if not bool(url.netloc) and ref[-5:] == '.html':
-            path = os.path.normpath(url.path)
+            path = os.path.normpath(os.path.join(os.path.dirname(file),url.path))
             if path in diff_pages:
                 logger.debug(f"This is a relative path to a diff'd page. Highlighting")
                 link['class'] = link.get('class', []) + ["link-to-diff"]

--- a/website_diff/page.py
+++ b/website_diff/page.py
@@ -142,9 +142,9 @@ def put_banner(diff_path, add_pages, del_pages):
             html_add = f.read()
         soup = BeautifulSoup(html_add, "html.parser")
         if page in add_pages:
-            markup = """<div class='alert add-banner'><span class='closebtn' onclick="this.parentElement.style.display='none';">&times;</span>This is an added page.</div>"""
+            markup = """<div class='alert add-banner'><span class='closebtn' onclick="this.parentElement.style.display='none';">&times;</span>This is a newly added page.</div>"""
         else:
-            markup = """<div class='alert del-banner'><span class='closebtn' onclick="this.parentElement.style.display='none';">&times;</span>This is a deleted page.</div>"""
+            markup = """<div class='alert del-banner'><span class='closebtn' onclick="this.parentElement.style.display='none';">&times;</span>This page was deleted from the website.</div>"""
         markup_soup = BeautifulSoup(markup, 'html.parser')
         soup.body.insert(1, markup_soup.div)
         # add css

--- a/website_diff/render/__init__.py
+++ b/website_diff/render/__init__.py
@@ -1,5 +1,6 @@
-from . import altair
 from . import prerender
+from . import altair
+from . import plotly
 
 tasks = {
     "flatten altair images" : altair.render

--- a/website_diff/render/plotly.py
+++ b/website_diff/render/plotly.py
@@ -1,0 +1,64 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.chrome.options import Options
+from selenium.common.exceptions import TimeoutException
+from bs4 import BeautifulSoup
+from loguru import logger
+import os
+import time
+
+def render(rootdir, relpath, soup, selector):
+    # Check if plotly div exists, if not return to avoid starting webdriver
+    if soup.find('div', class_='plotly') is None and soup.find('div', class_='plotly-graph-div') is None:
+        return
+
+    options = Options()
+    options.add_argument('--headless=new')
+    driver = webdriver.Chrome(options=options)
+
+    driver.get("file://" + os.path.abspath(rootdir))
+
+    # Wait for page to completely load
+    try:
+        WebDriverWait(driver, 30).until(
+            lambda driver: driver.execute_script("return document.readyState")
+            == "complete"
+        )
+    except TimeoutException as err:
+        raise TimeoutError("Page not loaded") from err
+
+    for el in driver.find_elements(By.CLASS_NAME, 'js-plotly-plot'):
+        viz_id = el.get_attribute('id')
+        viz = soup.find(id=viz_id)
+        script = viz.find_next_sibling('script')
+        logger.info(f"Found plotly viz {viz} with id {viz_id}")
+
+        # Scroll to element and pause for lazy loading
+        SCROLL_PAUSE_TIME = 1
+        driver.execute_script("arguments[0].scrollIntoView();", el)
+        time.sleep(SCROLL_PAUSE_TIME)
+
+        png_name = viz_id + ".png"
+        png_path = os.path.join(os.path.join(os.path.dirname(rootdir), relpath), png_name)
+                
+        # Replace plotly elements with img
+        if script is None:
+                logger.error(f"No data found for plotly viz with id {viz_id}")
+                continue
+
+        new_img = soup.new_tag("img", src=f"{os.path.join(relpath,png_name)}")
+        viz.insert_after(new_img)
+
+        viz.decompose()
+        script.decompose()
+
+        if os.path.exists(png_path):
+            logger.error(f"Existing png path! {png_path}")
+            continue
+
+        os.makedirs(os.path.dirname(png_path),exist_ok=True)
+        el.screenshot(png_path)
+
+    driver.quit()

--- a/website_diff/render/prerender.py
+++ b/website_diff/render/prerender.py
@@ -32,7 +32,11 @@ def _prerender_pages(dir, pages, selector):
 
         soup = BeautifulSoup(html, 'html.parser')
 
+        # Render altair visualizations
         wd.render.altair.render(filepath, 'prerendered', soup, selector)
+
+        # Render plotly visualizations
+        wd.render.plotly.render(filepath, 'prerendered', soup, selector)
 
         with open(filepath, 'w') as f:
             f.write(str(soup))

--- a/website_diff/static/website_diff.css
+++ b/website_diff/static/website_diff.css
@@ -48,4 +48,39 @@ ins.diff-selected > img {
 	color: darkred !important;
 }
 
+/* The alert message box */
+.alert {
+	color: white;
+	position: absolute;
+	right: 4rem;
+	top: 2rem;
+	z-index: 3;
+	border-bottom: none;
+	box-shadow: 5px 5px 10px 2px rgb(0 0 0 / .4);
 
+  }
+
+.alert.add-banner {
+	background-color: darkgreen;
+}
+
+.alert.del-banner {
+	background-color: darkred;
+}
+
+/* The close button */
+.closebtn {
+margin-left: 15px;
+color: white;
+font-weight: bold;
+float: right;
+font-size: 22px;
+line-height: 15px;
+cursor: pointer;
+transition: 0.3s;
+}
+
+/* When moving the mouse over the close button */
+.closebtn:hover {
+color: black;
+}

--- a/website_diff/target/image.py
+++ b/website_diff/target/image.py
@@ -1,5 +1,6 @@
 from PIL import Image, ImageEnhance, ImageChops, ImageOps
 import numpy as np
+import cairosvg
 from loguru import logger
 import os
 import shutil
@@ -48,3 +49,6 @@ def _highlight_image(filepath, filepath_out, color, alpha):
     overlay = Image.new("RGBA", img.size, color = color)
     blended = Image.blend(bw, overlay, alpha)
     blended.convert("RGB").save(filepath_out)
+
+def convert_svg_to_png(filepath, filepath_out):
+    cairosvg.svg2png(url=filepath, write_to=filepath_out)

--- a/website_diff/target/image.py
+++ b/website_diff/target/image.py
@@ -2,6 +2,7 @@ from PIL import Image, ImageEnhance, ImageChops, ImageOps
 import numpy as np
 from loguru import logger
 import os
+import shutil
 
 def diff(filepath_old, filepath_new, filepath_out):
     if not _img_exists(filepath_old, filepath_new):
@@ -11,8 +12,8 @@ def diff(filepath_old, filepath_new, filepath_out):
     img_new = Image.open(filepath_new).convert("RGB")
     img_diff = ImageChops.difference(img_old, img_new)
     if img_diff.getbbox() is None:
-        # no diff, just save img_new to filepath_out
-        img_new.save(filepath_out)
+        # no diff, just copy filepath_new to filepath_out
+        shutil.copyfile(filepath_new, filepath_out)
         return False
     else:
         # diff, add a yellow border and highlight differences in bright red


### PR DESCRIPTION
Closes #16 and closes #10:
- Now pre-renders plotly elements as PNG

Closes #23:
- Add closable banner on top right that tells you if the page was added or deleted

Closes #30:
- Now converts SVG files to PNG images

Closes #32:
- Does simple copy of images that have no diffs

Closes #33:
- Updated handling of links to changed pages
- Fixed bug in merge_diffs that was merging tags other than ins/del tags

Bump version to 0.1.0.